### PR TITLE
feat(formula): add `paneru`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,16 @@ jobs:
           brew install Formula/clavy.rb --HEAD
           clavy --help
 
+  paneru-head:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Test install
+        run: |
+          brew update
+          brew install Formula/paneru.rb --HEAD
+          paneru --help
+
   ouverture:
     runs-on: macos-latest
     steps:

--- a/Formula/paneru.rb
+++ b/Formula/paneru.rb
@@ -1,0 +1,30 @@
+# typed: false
+# frozen_string_literal: true
+
+class Paneru < Formula
+  desc "A sliding, tiling window manager for MacOS."
+  homepage "https://github.com/karinushka/paneru"
+  version "0.1.0"
+  license "MIT"
+  depends_on :macos
+
+  url "https://github.com/karinushka/paneru/releases/download/v#{version}/paneru_darwin_universal2.tar.gz"
+
+  def install
+    if build.head? then
+      system "cargo", "install", *std_cargo_args
+    else
+      bin.install "paneru"
+    end
+  end
+
+  head "https://github.com/karinushka/paneru.git", branch: "main"
+
+  head do
+    depends_on "rust" => :build
+  end
+
+  test do
+    system "#{bin}/paneru --help"
+  end
+end


### PR DESCRIPTION
## Caveats

The binary path is still a placeholder since there are actually no binaries, but if one uses `brew install paneru --HEAD` it should work.